### PR TITLE
Add MSVC compiler support

### DIFF
--- a/fabdef.h
+++ b/fabdef.h
@@ -389,9 +389,10 @@ struct fabdef {
 #pragma	pack	(pop)
 
 
-
+#ifndef _WIN32
 /* declare initialized prototype data structure */
 extern struct FAB cc$rms_fab __asm("_$$PsectAttributes_GLOBALSYMBOL$$cc$rms_fab");
 /* globalref struct FAB cc$rms_fab; */
+#endif
 
 #endif	/*_FABDEF_H*/

--- a/match.c
+++ b/match.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 
 #define ASTERISK '*'		/* The '*' metacharacter */

--- a/vmsbackup.c
+++ b/vmsbackup.c
@@ -92,6 +92,19 @@
 int mkdir ();
 #endif
 
+/* When the -c flag is used, choose an appropriate separator char
+   for the platform. */
+#ifdef _WIN32
+/* Windows uses a trailing colon (and text) to mean an alternate
+   data stream for the file, which is awkward to use in practice
+   and leads to trouble in the long run as Explorer does not
+   provide meaningful tools to deal with these. The VMS default
+   of semicolon works just fine. */
+#define VERSION_SEPARATOR_CHAR ';'
+#else
+#define VERSION_SEPARATOR_CHAR ':'
+#endif
+
 #include	"vmsbackup.h"
 #include	"sysdep.h"
 
@@ -318,7 +331,7 @@ int	procf = 1;
 	for (; *q && *q != ';'; q++)
 		if( *q == '.') ext = q;
 
-	*q = (cflag) ?  ':' : '\0';
+	*q = (cflag) ? VERSION_SEPARATOR_CHAR : '\0';
 
 	if (procf && wflag)
 		{

--- a/vmsbackup.c
+++ b/vmsbackup.c
@@ -57,6 +57,7 @@
 #include	<unixio.h>
 #else
 #ifdef _WIN32
+#include	<direct.h>
 #include	<io.h>
 #else
 #include	<unistd.h>
@@ -295,7 +296,12 @@ int	procf = 1;
 			s = *q;
 			*q = '\0';
 
-			if(procf && dflag) mkdir(p, 0777);
+			if (procf && dflag)
+#ifndef _WIN32
+				mkdir(p, 0777);
+#else
+				mkdir(p);
+#endif
 
 			*q = '/';
 

--- a/vmsbackup.c
+++ b/vmsbackup.c
@@ -576,7 +576,8 @@ ITM	*itm;
 
 				lnch = __cvt_uw (pdata + 12);
 				/* byte 14 unaccounted for */
-				if ( !(vfcsize = pdata + 15) )
+				vfcsize = *(pdata + 15);
+				if (vfcsize == 0)
 					vfcsize = 2;
 
 				/* bytes 16-31 unaccounted for */


### PR DESCRIPTION
This updates the source to allow MSVC compiler support in as minimal a fashion as possible. I also fixed the following:
1. [A bug in the assignment of vfcsize](https://github.com/SysMan-One/vmsbackup/pull/1/files#diff-0f3dd1e4ab5799f0c72e0ae21a93c97e4418f9c7ec85feeedf5cbc45a83dfc53R579-R580)
2. The wrong arguments being passed to printf's in DEBUG regions
3. An uninitialized variable (`id`) hit while unpacking a saveset

If you would prefer to forgo the MSVC specific changes, I can cherry-pick just the generic bug fixes.